### PR TITLE
Removed direct/hard dependency to database

### DIFF
--- a/Adapter/AbstractCurrencyAdapter.php
+++ b/Adapter/AbstractCurrencyAdapter.php
@@ -20,6 +20,11 @@ abstract class AbstractCurrencyAdapter extends \ArrayIterator
     protected $managedCurrencies = array();
 
     /**
+     * @var string
+     */
+    protected $currencyClass;
+
+    /**
      * Set default currency
      *
      * @param string $defaultCurrency
@@ -75,7 +80,7 @@ abstract class AbstractCurrencyAdapter extends \ArrayIterator
      * @param mixed $index
      * @param Currency $newval
      */
-    public function offsetSet ($index, $newval)
+    public function offsetSet($index, $newval)
     {
         if (!$newval instanceof $this->currencyClass) {
             throw new \InvalidArgumentException(sprintf('$newval must be an instance of Currency, instance of "%s" given', get_class($newval)));

--- a/Adapter/AdapterFactory.php
+++ b/Adapter/AdapterFactory.php
@@ -69,18 +69,10 @@ class AdapterFactory
         if (null == $adapterClass) {
             $adapterClass = 'Lexik\Bundle\CurrencyBundle\Adapter\DoctrineCurrencyAdapter';
         }
-
         $adapter = $this->create($adapterClass);
 
         $em = $this->doctrine->getManager($entityManagerName);
-
-        $currencies = $em
-            ->getRepository($this->currencyClass)
-            ->findAll();
-
-        foreach ($currencies as $currency) {
-            $adapter[$currency->getCode()] = $currency;
-        }
+        $adapter->setManager($em);
 
         return $adapter;
     }

--- a/Adapter/DoctrineCurrencyAdapter.php
+++ b/Adapter/DoctrineCurrencyAdapter.php
@@ -2,12 +2,25 @@
 
 namespace Lexik\Bundle\CurrencyBundle\Adapter;
 
+use Doctrine\ORM\EntityManager;
+use Exception;
+
 /**
  * @author Yoann Aparici <y.aparici@lexik.fr>
  * @author Cédric Girard <c.girard@lexik.fr>
  */
 class DoctrineCurrencyAdapter extends AbstractCurrencyAdapter
 {
+    /**
+     * @var ObjectManager
+     */
+    private $manager;
+
+    /**
+     * @var bool
+     */
+    private $initialized = false;
+
     /**
      * {@inheritdoc}
      */
@@ -24,5 +37,53 @@ class DoctrineCurrencyAdapter extends AbstractCurrencyAdapter
     public function getIdentifier()
     {
         return 'doctrine';
+    }
+
+    /**
+     * @param EntityManager $manager
+     */
+    public function setManager(EntityManager $manager)
+    {
+        $this->manager = $manager;
+    }
+
+    public function offsetExists($index)
+    {
+        if (!$this->isInitialized()) {
+            $this->initialize();
+        }
+        return parent::offsetExists($index);
+    }
+
+    public function offsetGet($index)
+    {
+        if (!$this->isInitialized()) {
+            $this->initialize();
+        }
+
+        return parent::offsetGet($index);
+    }
+
+    /**
+     * @return bool
+     */
+    private function isInitialized()
+    {
+        return $this->initialized;
+    }
+
+    private function initialize()
+    {
+        if (!isset($this->manager)) {
+            throw new Exception('No ObjectManager set');
+        }
+
+        $currencies = $this->manager
+            ->getRepository($this->currencyClass)
+            ->findAll();
+
+        foreach ($currencies as $currency) {
+            $this[$currency->getCode()] = $currency;
+        }
     }
 }


### PR DESCRIPTION
Problems:
- The database table (lexik_currency) is queried each time you execute a various console command, even if you don't need the bundle at all.
- You have to create the database table before you install the bundle (not possible to add it via database migration, because of the previous issue)
- Problems functional tests when you try to create a sqlite fixture but the database table was required to be available when the command starts..

Solution:
Moved database queries out of factory method into DoctrineCurrencyAdapter.
Only query the database when it is needed.
(better performance, less dependency to a database, better possibilities for testing)