### PR TITLE
Mapped superclass currency entity

### DIFF
--- a/Resources/config/doctrine/Currency.orm.xml
+++ b/Resources/config/doctrine/Currency.orm.xml
@@ -3,11 +3,11 @@
       xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
                     http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
 
-    <entity name="Lexik\Bundle\CurrencyBundle\Entity\Currency" table="lexik_currency">
+    <mapped-superclass name="Lexik\Bundle\CurrencyBundle\Entity\Currency" table="lexik_currency">
         <id name="id" type="integer" column="id">
             <generator strategy="AUTO" />
         </id>
         <field name="code" column="code" type="string" length="3" />
         <field name="rate" column="rate" type="decimal" scale="4" />
-    </entity>
+    </mapped-superclass>
 </doctrine-mapping>


### PR DESCRIPTION
If we overload entity currency with parameter 'lexik_currency.currency_class', two entities are created.

Fix bug - currency entity is mapped superclass