### PR TITLE
Refactor for PHP 8.x and Symfony 5.x

### DIFF
--- a/Adapter/AbstractCurrencyAdapter.php
+++ b/Adapter/AbstractCurrencyAdapter.php
@@ -2,114 +2,91 @@
 
 namespace Lexik\Bundle\CurrencyBundle\Adapter;
 
+use ArrayIterator;
+use Lexik\Bundle\CurrencyBundle\Entity\Currency;
+
 /**
  *
  * @author Cédric Girard <c.girard@lexik.fr>
  * @author Yoann Aparici <y.aparici@lexik.fr>
+ * @extends ArrayIterator<string, Currency>
  */
-abstract class AbstractCurrencyAdapter extends \ArrayIterator
+abstract class AbstractCurrencyAdapter extends ArrayIterator
 {
-    /**
-     * @var string
-     */
-    protected $defaultCurrency;
+    protected string $defaultCurrency;
 
     /**
-     * @var array
+     * @var array<string>
      */
-    protected $managedCurrencies = array();
+    protected array $managedCurrencies = [];
 
     /**
-     * @var string
+     * @var class-string
      */
-    protected $currencyClass;
+    protected string $currencyClass;
 
-    /**
-     * Set default currency
-     *
-     * @param string $defaultCurrency
-     */
-    public function setDefaultCurrency($defaultCurrency)
+    public function setDefaultCurrency(string $defaultCurrency): void
     {
         $this->defaultCurrency = $defaultCurrency;
     }
 
-    /**
-     * Get default currency
-     *
-     * @return string
-     */
-    public function getDefaultCurrency()
+    public function getDefaultCurrency(): string
     {
         return $this->defaultCurrency;
     }
 
     /**
-     * Get managedCurrencies
-     *
-     * @param array $currencies
+     * @param array<string> $currencies
      */
-    public function setManagedCurrencies($currencies)
+    public function setManagedCurrencies(array $currencies): void
     {
         $this->managedCurrencies = $currencies;
     }
 
     /**
-     * Get managedCurrencies
-     *
-     * @return array
+     * @return array<string>
      */
-    public function getManagedCurrencies()
+    public function getManagedCurrencies(): array
     {
         return $this->managedCurrencies;
     }
 
     /**
-     * Get managedCurrencies
-     *
-     * @return array
+     * @param class-string $currencyClass
      */
-    public function setCurrencyClass($currencyClass)
+    public function setCurrencyClass(string $currencyClass): void
     {
-        return $this->currencyClass = $currencyClass;
+        $this->currencyClass = $currencyClass;
     }
 
     /**
-     * Set object
-     *
-     * @param mixed $index
-     * @param Currency $newval
-     */
-    public function offsetSet($index, $newval)
-    {
-        if (!$newval instanceof $this->currencyClass) {
-            throw new \InvalidArgumentException(sprintf('$newval must be an instance of Currency, instance of "%s" given', get_class($newval)));
-        }
-
-        parent::offsetSet($index, $newval);
-    }
-
-    /**
-     * Append a value
-     *
+     * @param string $key
      * @param Currency $value
      */
-    public function append($value)
+    public function offsetSet($key, $value): void
     {
         if (!$value instanceof $this->currencyClass) {
-            throw new \InvalidArgumentException(sprintf('$newval must be an instance of Currency, instance of "%s" given', get_class($value)));
+            throw new \InvalidArgumentException(sprintf('$newval must be an instance of Currency, instance of "%s" given', $value::class));
+        }
+
+        parent::offsetSet($key, $value);
+    }
+
+    /**
+     * @param Currency $value
+     */
+    public function append($value): void
+    {
+        if (!$value instanceof $this->currencyClass) {
+            throw new \InvalidArgumentException(sprintf('$newval must be an instance of Currency, instance of "%s" given', $value::class));
         }
 
         parent::append($value);
     }
 
-    /**
-     * Convert all
-     *
-     * @param mixed $rate
-     */
-    protected function convertAll($rate)
+    protected function convertAll(float $rate): void
     {
+        /** @var Currency $currency */
         foreach ($this as $currency) {
             $currency->convert($rate);
         }
@@ -119,13 +96,11 @@ abstract class AbstractCurrencyAdapter extends \ArrayIterator
      * This method is used by the constructor
      * to attach all currencies.
      */
-    abstract public function attachAll();
+    abstract public function attachAll(): void;
 
     /**
-     * Get identier value for the adapter must be unique
+     * Get identifier value for the adapter must be unique
      * for all the project
-     *
-     * @return string
      */
-    abstract protected function getIdentifier();
+    abstract public function getIdentifier(): string;
 }

--- a/Adapter/AdapterCollector.php
+++ b/Adapter/AdapterCollector.php
@@ -9,26 +9,17 @@ use InvalidArgumentException;
  */
 final class AdapterCollector
 {
-    private $elements = array();
-
     /**
-     * Add an adapter
-     *
-     * @param mixed $key
-     * @param AbstractCurrencyAdapter $adapter
+     * @var array<string, AbstractCurrencyAdapter>
      */
-    public function add(AbstractCurrencyAdapter $adapter)
+    private array $elements = [];
+
+    public function add(AbstractCurrencyAdapter $adapter): void
     {
         $this->elements[$adapter->getIdentifier()] = $adapter;
     }
 
-    /**
-     * Get adapter
-     *
-     * @param mixed $key
-     * @return AbstractCurrencyAdapter
-     */
-    public function get($key)
+    public function get(string $key): AbstractCurrencyAdapter
     {
         if (!isset($this->elements[$key])) {
             throw new InvalidArgumentException('Adapter does not exist');
@@ -36,5 +27,4 @@ final class AdapterCollector
 
         return $this->elements[$key];
     }
-
 }

--- a/Adapter/AdapterFactory.php
+++ b/Adapter/AdapterFactory.php
@@ -2,55 +2,44 @@
 
 namespace Lexik\Bundle\CurrencyBundle\Adapter;
 
-use Doctrine\ORM\EntityManager;
 use Doctrine\Bundle\DoctrineBundle\Registry;
+use Doctrine\ORM\EntityManager;
 
 /**
- * This class is used to create DoctrineCurrencyAdapter
- *
  * @author Yoann Aparici <y.aparici@lexik.fr>
  * @author Cédric Girard <c.girard@lexik.fr>
  */
 class AdapterFactory
 {
     /**
-     * @var EntityManager
+     * @var array{default: string, managed: array<string>}
      */
-    protected $doctrine;
+    private array $currencies;
 
     /**
-     * @var array
+     * @param Registry $doctrine
+     * @param string $defaultCurrency
+     * @param array<string> $availableCurrencies
+     * @param class-string $currencyClass
      */
-    private $currencies;
-
-    /**
-     * @var string
-     */
-    private $currencyClass;
-
-    /**
-     * __construct
-     *
-     * @param EntityManager $em
-     */
-    public function __construct(Registry $doctrine, $defaultCurrency, $availableCurrencies, $currencyClass)
-    {
-        $this->doctrine = $doctrine;
-
-        $this->currencies = array();
-        $this->currencies['default'] = $defaultCurrency;
-        $this->currencies['managed'] = $availableCurrencies;
-        $this->currencyClass = $currencyClass;
+    public function __construct(
+        protected Registry $doctrine,
+        string $defaultCurrency,
+        array $availableCurrencies,
+        private string $currencyClass
+    ) {
+        $this->currencies = [
+            'default' => $defaultCurrency,
+            'managed' => $availableCurrencies
+        ];
     }
 
     /**
-     * Create an adaper from the given class.
-     *
-     * @param string $adapterClass
-     * @return Lexik\Bundle\CurrencyBundle\Adapter\AbstractCurrencyAdapter
+     * @param class-string $adapterClass
      */
-    public function create($adapterClass)
+    public function create(string $adapterClass): AbstractCurrencyAdapter
     {
+        /** @var AbstractCurrencyAdapter $adapter */
         $adapter = new $adapterClass();
         $adapter->setDefaultCurrency($this->currencies['default']);
         $adapter->setManagedCurrencies($this->currencies['managed']);
@@ -60,17 +49,17 @@ class AdapterFactory
     }
 
     /**
-     * Create a DoctrineCurrencyAdapter.
-     *
-     * @return Lexik\Bundle\CurrencyBundle\Adapter\DoctrineCurrencyAdapter
+     * @param ?class-string $adapterClass
      */
-    public function createDoctrineAdapter($adapterClass = null, $entityManagerName = null)
+    public function createDoctrineAdapter(string $adapterClass = null, string $entityManagerName = null): AbstractCurrencyAdapter
     {
         if (null == $adapterClass) {
-            $adapterClass = 'Lexik\Bundle\CurrencyBundle\Adapter\DoctrineCurrencyAdapter';
+            $adapterClass = DoctrineCurrencyAdapter::class;
         }
+        /** @var DoctrineCurrencyAdapter $adapter */
         $adapter = $this->create($adapterClass);
 
+        /** @var EntityManager $em */
         $em = $this->doctrine->getManager($entityManagerName);
         $adapter->setManager($em);
 
@@ -78,42 +67,36 @@ class AdapterFactory
     }
 
     /**
-     * Create an EcbCurrencyAdapter.
-     *
-     * @return Lexik\Bundle\CurrencyBundle\Adapter\EcbCurrencyAdapter
+     * @param ?class-string $adapterClass
      */
-    public function createEcbAdapter($adapterClass = null)
+    public function createEcbAdapter(string $adapterClass = null): AbstractCurrencyAdapter
     {
         if (null == $adapterClass) {
-            $adapterClass = 'Lexik\Bundle\CurrencyBundle\Adapter\EcbCurrencyAdapter';
+            $adapterClass = EcbCurrencyAdapter::class;
         }
 
         return $this->create($adapterClass);
     }
 
     /**
-     * Create an OerCurrencyAdapter.
-     *
-     * @return Lexik\Bundle\CurrencyBundle\Adapter\OerCurrencyAdapter
+     * @param ?class-string $adapterClass
      */
-    public function createOerAdapter($adapterClass = null)
+    public function createOerAdapter(string $adapterClass = null): AbstractCurrencyAdapter
     {
         if (null == $adapterClass) {
-            $adapterClass = 'Lexik\Bundle\CurrencyBundle\Adapter\OerCurrencyAdapter';
+            $adapterClass = OerCurrencyAdapter::class;
         }
 
         return $this->create($adapterClass);
     }
 
     /**
-     * Create an YahooCurrencyAdapter.
-     *
-     * @return Lexik\Bundle\CurrencyBundle\Adapter\YahooCurrencyAdapter
+     * @param ?class-string $adapterClass
      */
-    public function createYahooAdapter($adapterClass = null)
+    public function createYahooAdapter(string $adapterClass = null): AbstractCurrencyAdapter
     {
         if (null == $adapterClass) {
-            $adapterClass = 'Lexik\Bundle\CurrencyBundle\Adapter\YahooCurrencyAdapter';
+            $adapterClass = YahooCurrencyAdapter::class;
         }
 
         return $this->create($adapterClass);

--- a/Adapter/DoctrineCurrencyAdapter.php
+++ b/Adapter/DoctrineCurrencyAdapter.php
@@ -3,6 +3,9 @@
 namespace Lexik\Bundle\CurrencyBundle\Adapter;
 
 use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
+use Exception;
+use Lexik\Bundle\CurrencyBundle\Entity\Currency;
 
 /**
  * @author Yoann Aparici <y.aparici@lexik.fr>
@@ -10,46 +13,21 @@ use Doctrine\ORM\EntityManager;
  */
 class DoctrineCurrencyAdapter extends AbstractCurrencyAdapter
 {
-    /**
-     * @var EntityManager
-     */
-    private $manager;
+    private EntityManager $manager;
 
-    /**
-     * @var bool
-     */
-    private $initialized = false;
+    private bool $initialized = false;
 
-    /**
-     * {@inheritdoc}
-     */
-    public function attachAll()
+    public function attachAll(): void
     {
         // nothing here
     }
 
-    /**
-     * Return identifier
-     *
-     * @return string
-     */
-    public function getIdentifier()
+    public function getIdentifier(): string
     {
         return 'doctrine';
     }
 
-    /**
-     * @param EntityManager $manager
-     */
-    public function setManager(EntityManager $manager)
-    {
-        $this->manager = $manager;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function offsetExists($index)
+    public function offsetExists($index): bool
     {
         if (!$this->isInitialized()) {
             $this->initialize();
@@ -58,30 +36,29 @@ class DoctrineCurrencyAdapter extends AbstractCurrencyAdapter
         return parent::offsetExists($index);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function offsetGet($index)
+    public function setManager(EntityManager $manager): void
+    {
+        $this->manager = $manager;
+    }
+
+    public function offsetGet(mixed $key): mixed
     {
         if (!$this->isInitialized()) {
             $this->initialize();
         }
 
-        return parent::offsetGet($index);
+        return parent::offsetGet($key);
     }
 
-    /**
-     * @return bool
-     */
-    private function isInitialized()
+    private function isInitialized(): bool
     {
         return $this->initialized;
     }
 
     /**
-     * @throws \Exception
+     * @throws Exception
      */
-    private function initialize()
+    private function initialize(): void
     {
         if (!isset($this->manager)) {
             throw new \RuntimeException('No ObjectManager set on DoctrineCurrencyAdapter.');
@@ -91,6 +68,7 @@ class DoctrineCurrencyAdapter extends AbstractCurrencyAdapter
             ->getRepository($this->currencyClass)
             ->findAll();
 
+        /** @var Currency $currency */
         foreach ($currencies as $currency) {
             $this[$currency->getCode()] = $currency;
         }

--- a/Currency/Converter.php
+++ b/Currency/Converter.php
@@ -6,53 +6,36 @@ use Lexik\Bundle\CurrencyBundle\Adapter\AbstractCurrencyAdapter;
 use Lexik\Bundle\CurrencyBundle\Exception\CurrencyNotFoundException;
 
 /**
- * Currency converter.
- *
  * @author Cédric Girard <c.girard@lexik.fr>
  * @author Yoann Aparici <y.aparici@lexik.fr>
  */
 class Converter implements ConverterInterface
 {
-    /**
-     * @var AbstractCurrencyAdapter
-     */
-    protected $adapter;
+    private int $roundMode;
 
     /**
-     * @var integer
-     */
-    protected $precision;
-
-    /**
-     * @var string
-     */
-    protected $roundMode;
-
-    /**
-     * Construct.
-     *
-     * @param AbstractCurrencyAdapter $adapter
-     * @param integer                 $precision
-     * @param string                  $roundMode
      * @throws \InvalidArgumentException
      */
-    public function __construct(AbstractCurrencyAdapter $adapter, $precision = 2, $roundMode = 'up')
+    public function __construct(protected AbstractCurrencyAdapter $adapter, protected int $precision = 2, string $roundMode = 'up')
     {
-        $allowedModes = array('up', 'down', 'even', 'odd');
+        $allowedModes = ['up', 'down', 'even', 'odd'];
 
         if (!in_array($roundMode, $allowedModes)) {
-            throw new \InvalidArgumentException(sprintf('Invalid round mode "%s", please use one of the following values: %s', $roundMode, implode(', ', $allowedModes)));
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'Invalid round mode "%s", please use one of the following values: %s',
+                    $roundMode,
+                    implode(', ', $allowedModes)
+                )
+            );
         }
 
-        $this->adapter = $adapter;
-        $this->precision = $precision;
-        $this->roundMode = constant(sprintf('PHP_ROUND_HALF_%s', strtoupper($roundMode)));
+        /** @var int $roundingConstant */
+        $roundingConstant = constant(sprintf('PHP_ROUND_HALF_%s', strtoupper($roundMode)));
+        $this->roundMode = $roundingConstant;
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function convert($value, $targetCurrency, $round = true, $valueCurrency = null)
+    public function convert(float $value, string $targetCurrency, bool $round = true, string $valueCurrency = null): float
     {
         if (!isset($this->adapter[$targetCurrency])) {
             throw new CurrencyNotFoundException($targetCurrency);
@@ -66,26 +49,22 @@ class Converter implements ConverterInterface
             throw new CurrencyNotFoundException($valueCurrency);
         }
 
-        if ($targetCurrency != $valueCurrency) {
-            if ($this->getDefaultCurrency() == $valueCurrency) {
+        if ($targetCurrency !== $valueCurrency) {
+            if ($this->getDefaultCurrency() === $valueCurrency) {
                 $value *= $this->adapter[$targetCurrency]->getRate();
-
             } else {
                 $value /= $this->adapter[$valueCurrency]->getRate(); // value in the default currency
 
-                if ($this->getDefaultCurrency() != $targetCurrency) {
+                if ($this->getDefaultCurrency() !== $targetCurrency) {
                     $value *= $this->adapter[$targetCurrency]->getRate();
                 }
             }
         }
 
-        return $round ? round($value, $this->precision, $this->roundMode) : $value;
+        return $round ? round($value, $this->precision, (int) $this->roundMode) : $value;
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function getDefaultCurrency()
+    public function getDefaultCurrency(): string
     {
         return $this->adapter->getDefaultCurrency();
     }

--- a/Currency/ConverterInterface.php
+++ b/Currency/ConverterInterface.php
@@ -9,19 +9,8 @@ interface ConverterInterface
 {
     /**
      * Convert from default currency to another.
-     *
-     * @param float   $value
-     * @param string  $targetCurrency
-     * @param boolean $round
-     * @param string  $valueCurrency
-     * @return float
      */
-    public function convert($value, $targetCurrency, $round = true, $valueCurrency = null);
+    public function convert(float $value, string $targetCurrency, bool $round = true, string $valueCurrency = null): float;
 
-    /**
-     * Get default currency.
-     *
-     * @return string
-     */
-    public function getDefaultCurrency();
+    public function getDefaultCurrency(): string;
 }

--- a/Currency/Formatter.php
+++ b/Currency/Formatter.php
@@ -3,62 +3,45 @@
 namespace Lexik\Bundle\CurrencyBundle\Currency;
 
 /**
- * Currency formatter.
- *
  * @author Cédric Girard <c.girard@lexik.fr>
  */
 class Formatter implements FormatterInterface
 {
     /**
-     * @var string
+     * @var array<string>
      */
-    protected $locale;
+    protected array $cleanCharacters;
 
-    /**
-     * @var array
-     */
-    protected $cleanCharacters;
-
-    /**
-     * @param sting $locale
-     */
-    public function __construct($locale)
+    public function __construct(protected string $locale)
     {
-        $this->locale = $locale;
-        $this->cleanCharacters = array('EU', 'UK', 'US');
+        $this->cleanCharacters = ['EU', 'UK', 'US'];
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function format($value, $valueCurrency = null, $decimal = true, $symbol = true)
+    public function format(float $value, string $valueCurrency = '', bool $decimal = true, bool $symbol = true): ?string
     {
         $formatter = new \NumberFormatter($this->locale, $symbol ? \NumberFormatter::CURRENCY : \NumberFormatter::PATTERN_DECIMAL);
         $value = $formatter->formatCurrency($value, $valueCurrency);
 
         if (!$decimal) {
-            $value = preg_replace('/[.,]00((?=\D)|$)/', '', $value);
+            $value = (string) preg_replace('/[.,]00((?=\D)|$)/', '', $value);
         }
 
-        if (count($this->cleanCharacters) > 0) {
+        if ($this->cleanCharacters !== []) {
             $value = str_replace($this->cleanCharacters, '', $value);
         }
 
         return $value;
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function setLocale($locale)
+    public function setLocale(string $locale): void
     {
-        $this->locale = (string) $locale;
+        $this->locale = $locale;
     }
 
     /**
-     * @param array $cleanCharacters
+     * @param array<string> $cleanCharacters
      */
-    public function setCleanCharacters(array $cleanCharacters)
+    public function setCleanCharacters(array $cleanCharacters): void
     {
         $this->cleanCharacters = $cleanCharacters;
     }

--- a/Currency/FormatterInterface.php
+++ b/Currency/FormatterInterface.php
@@ -7,21 +7,7 @@ namespace Lexik\Bundle\CurrencyBundle\Currency;
  */
 interface FormatterInterface
 {
-    /**
-     * Format a given value.
-     *
-     * @param string  $value
-     * @param null    $valueCurrency
-     * @param boolean $decimal
-     * @param boolean $symbol
-     * @return string
-     */
-    public function format($value, $valueCurrency = null, $decimal = true, $symbol = true);
+    public function format(float $value, string $valueCurrency = '', bool $decimal = true, bool $symbol = true): ?string;
 
-    /**
-     * Set the locale to use to format the value.
-     *
-     * @param string $locale
-     */
-    public function setLocale($locale);
+    public function setLocale(string $locale): void;
 }

--- a/DependencyInjection/Compiler/AdapterPass.php
+++ b/DependencyInjection/Compiler/AdapterPass.php
@@ -2,8 +2,8 @@
 
 namespace Lexik\Bundle\CurrencyBundle\DependencyInjection\Compiler;
 
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
@@ -11,13 +11,13 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class AdapterPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         // Attach all adapter to the adapter collector
         $definition = $container->getDefinition('lexik_currency.adapter_collector');
 
-        foreach ($container->findTaggedServiceIds('lexik_currency.adapter') as $id => $attributes) {
-            $definition->addMethodCall('add', array(new Reference($id)));
+        foreach (array_keys($container->findTaggedServiceIds('lexik_currency.adapter')) as $id) {
+            $definition->addMethodCall('add', [new Reference($id)]);
         }
 
         // set default adapter alias

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -5,18 +5,12 @@ namespace Lexik\Bundle\CurrencyBundle\DependencyInjection;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
-/**
- * This is the class that validates and merges configuration from your app/config files
- */
 class Configuration implements ConfigurationInterface
 {
-    /**
-     * {@inheritDoc}
-     */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('lexik_currency');
+        $treeBuilder = new TreeBuilder('lexik_currency');
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode
             ->addDefaultsIfNotSet()
@@ -30,7 +24,7 @@ class Configuration implements ConfigurationInterface
                             ->isRequired()
                         ->end()
                         ->arrayNode('managed')
-                            ->defaultValue(array('EUR'))
+                            ->defaultValue(['EUR'])
                             ->isRequired()
                             ->prototype('scalar')
                             ->end()

--- a/DependencyInjection/LexikCurrencyExtension.php
+++ b/DependencyInjection/LexikCurrencyExtension.php
@@ -2,10 +2,10 @@
 
 namespace Lexik\Bundle\CurrencyBundle\DependencyInjection;
 
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
  * This is the class that loads and manages your bundle configuration
@@ -13,14 +13,14 @@ use Symfony\Component\DependencyInjection\Loader;
 class LexikCurrencyExtension extends Extension
 {
     /**
-     * {@inheritDoc}
+     * @param string[] $configs
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 
-        $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.xml');
         $loader->load('adapters.xml');
 

--- a/Entity/Currency.php
+++ b/Entity/Currency.php
@@ -9,85 +9,48 @@ use Symfony\Component\Validator\Constraints as Assert;
  */
 class Currency
 {
-    /**
-     * @var int
-     */
-    protected $id;
+    protected int $id;
 
     /**
      * @Assert\Length(min=3)
      * @Assert\Length(max=3)
      * @Assert\NotBlank()
      * @Assert\Type(type="string")
-     *
-     * @var string
      */
-    protected $code;
+    protected string $code;
 
     /**
      * @Assert\NotBlank()
      * @Assert\Type(type="numeric")
-     *
-     * @var string
      */
-    protected $rate;
+    protected float $rate;
 
-    /**
-     * Get ID
-     *
-     * @return string
-     */
-    public function getId()
+    public function getId(): int
     {
         return $this->id;
     }
 
-    /**
-     * Get code
-     *
-     * @return string
-     */
-    public function getCode()
+    public function getCode(): string
     {
         return $this->code;
     }
 
-    /**
-     * Set code
-     *
-     * @param string $code
-     */
-    public function setCode($code)
+    public function setCode(string $code): void
     {
         $this->code = $code;
     }
 
-    /**
-     * Get rate
-     *
-     * @return string
-     */
-    public function getRate()
+    public function getRate(): float
     {
         return $this->rate;
     }
 
-    /**
-     * Set rate
-     *
-     * @param string $rate
-     */
-    public function setRate($rate)
+    public function setRate(float $rate): void
     {
         $this->rate = $rate;
     }
 
-    /**
-     * Convert currency rate
-     *
-     * @param float $rate
-     */
-    public function convert($rate)
+    public function convert(float $rate): void
     {
         $this->rate /= $rate;
     }

--- a/EventListener/LocaleListener.php
+++ b/EventListener/LocaleListener.php
@@ -4,7 +4,7 @@ namespace Lexik\Bundle\CurrencyBundle\EventListener;
 
 use Lexik\Bundle\CurrencyBundle\Currency\FormatterInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 /**
@@ -12,35 +12,24 @@ use Symfony\Component\HttpKernel\KernelEvents;
  */
 class LocaleListener implements EventSubscriberInterface
 {
-    /**
-     * @var \Lexik\Bundle\CurrencyBundle\Currency\FormatterInterface
-     */
-    private $formatter;
-
-    /**
-     * @param FormatterInterface $formatter
-     */
-    public function __construct(FormatterInterface $formatter)
+    public function __construct(private FormatterInterface $formatter)
     {
-        $this->formatter = $formatter;
     }
 
     /**
-     * {@inheritDoc}
+     * @return array<string, array<int[]|string[]>>
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
-        return array(
-            KernelEvents::REQUEST => array(
-                array('setCurrencyFormatterLocale', 17) // must be registered before the default Locale listener
-            ),
-        );
+        return [
+            KernelEvents::REQUEST => [
+                // must be registered before the default Locale listener
+                ['setCurrencyFormatterLocale', 17]
+            ],
+        ];
     }
 
-    /**
-     * @param GetResponseEvent $event
-     */
-    public function setCurrencyFormatterLocale(GetResponseEvent $event)
+    public function setCurrencyFormatterLocale(RequestEvent $event): void
     {
         $request = $event->getRequest();
 

--- a/Exception/CurrencyNotFoundException.php
+++ b/Exception/CurrencyNotFoundException.php
@@ -8,8 +8,8 @@ namespace Lexik\Bundle\CurrencyBundle\Exception;
  */
 class CurrencyNotFoundException extends \InvalidArgumentException
 {
-    public function __construct($currency)
+    public function __construct(string $currency)
     {
-        parent::__construct(sprintf('Can\'t find currency: "%s"', $currency));
+        parent::__construct(sprintf('Cannot find currency: "%s"', $currency));
     }
 }

--- a/LexikCurrencyBundle.php
+++ b/LexikCurrencyBundle.php
@@ -3,8 +3,8 @@
 namespace Lexik\Bundle\CurrencyBundle;
 
 use Lexik\Bundle\CurrencyBundle\DependencyInjection\Compiler\AdapterPass;
-use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class LexikCurrencyBundle extends Bundle
 {

--- a/Resources/config/adapters.xml
+++ b/Resources/config/adapters.xml
@@ -17,7 +17,7 @@
 
     <services>
         <!-- Adapter collector -->
-        <service id="lexik_currency.adapter_collector" class="%lexik_currency.adapter_collector.class%" />
+        <service id="lexik_currency.adapter_collector" class="%lexik_currency.adapter_collector.class%" public="true" />
 
         <!-- Factory -->
         <service id="lexik_currency.adapter_factory" class="%lexik_currency.adapter_factory.class%">

--- a/Tests/Fixtures/CurrencyData.php
+++ b/Tests/Fixtures/CurrencyData.php
@@ -2,10 +2,10 @@
 
 namespace Lexik\Bundle\CurrencyBundle\Tests\Fixtures;
 
-use Lexik\Bundle\CurrencyBundle\Entity\Currency;
-
 use Doctrine\Common\DataFixtures\FixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+
+use Doctrine\Persistence\ObjectManager;
+use Lexik\Bundle\CurrencyBundle\Entity\Currency;
 
 /**
  * Tests fixtures class.
@@ -14,15 +14,12 @@ use Doctrine\Common\Persistence\ObjectManager;
  */
 class CurrencyData implements FixtureInterface
 {
-    /**
-     * @see Doctrine\Common\DataFixtures.FixtureInterface::load()
-     */
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
-        $values = array(
-            array('code' => 'EUR', 'rate' => 1),
-            array('code' => 'USD', 'rate' => 1.3),
-        );
+        $values = [
+            ['code' => 'EUR', 'rate' => 1.0],
+            ['code' => 'USD', 'rate' => 1.3],
+        ];
 
         foreach ($values as $data) {
             $currency = new Currency();

--- a/Tests/Unit/Adapter/AdapterFactoryTest.php
+++ b/Tests/Unit/Adapter/AdapterFactoryTest.php
@@ -2,58 +2,59 @@
 
 namespace Lexik\Bundle\CurrencyBundle\Tests\Unit\Adapter;
 
+use Doctrine\Bundle\DoctrineBundle\Registry;
 use Lexik\Bundle\CurrencyBundle\Adapter\AdapterFactory;
+use Lexik\Bundle\CurrencyBundle\Adapter\DoctrineCurrencyAdapter;
+use Lexik\Bundle\CurrencyBundle\Adapter\EcbCurrencyAdapter;
+use Lexik\Bundle\CurrencyBundle\Adapter\YahooCurrencyAdapter;
+use Lexik\Bundle\CurrencyBundle\Entity\Currency;
 use Lexik\Bundle\CurrencyBundle\Tests\Unit\BaseUnitTestCase;
 
 class AdapterFactoryTest extends BaseUnitTestCase
 {
-    const CURRENCY_ENTITY = 'Lexik\Bundle\CurrencyBundle\Entity\Currency';
-
-    protected $doctrine;
-
-    public function setUp()
+    public function setUp(): void
     {
         $this->doctrine = $this->getMockDoctrine();
         $em = $this->getEntityManager();
         $this->createSchema($em);
     }
 
-    public function testCreateEcbAdapter()
+    public function testCreateEcbAdapter(): void
     {
-        $factory = new AdapterFactory($this->doctrine, 'EUR', array('EUR', 'USD'), self::CURRENCY_ENTITY);
+        $factory = new AdapterFactory($this->doctrine, 'EUR', ['EUR', 'USD'], Currency::class);
         $adapter = $factory->createEcbAdapter();
 
-        $this->assertInstanceOf('Lexik\Bundle\CurrencyBundle\Adapter\EcbCurrencyAdapter', $adapter);
+        $this->assertInstanceOf(EcbCurrencyAdapter::class, $adapter);
         $this->assertEquals('EUR', $adapter->getDefaultCurrency());
-        $this->assertEquals(array('EUR', 'USD'), $adapter->getManagedCurrencies());
+        $this->assertEquals(['EUR', 'USD'], $adapter->getManagedCurrencies());
         $this->assertEquals(0, count($adapter));
     }
 
-    public function testCreateYahooAdapter()
+    public function testCreateYahooAdapter(): void
     {
-        $factory = new AdapterFactory($this->doctrine, 'EUR', array('EUR', 'USD'), self::CURRENCY_ENTITY);
+        $factory = new AdapterFactory($this->doctrine, 'EUR', ['EUR', 'USD'], Currency::class);
         $adapter = $factory->createYahooAdapter();
 
-        $this->assertInstanceOf('Lexik\Bundle\CurrencyBundle\Adapter\YahooCurrencyAdapter', $adapter);
+        $this->assertInstanceOf(YahooCurrencyAdapter::class, $adapter);
         $this->assertEquals('EUR', $adapter->getDefaultCurrency());
-        $this->assertEquals(array('EUR', 'USD'), $adapter->getManagedCurrencies());
+        $this->assertEquals(['EUR', 'USD'], $adapter->getManagedCurrencies());
         $this->assertEquals(0, count($adapter));
     }
 
-    public function testCreateDoctrineAdapter()
+    public function testCreateDoctrineAdapter(): void
     {
         $em = $this->getEntityManager();
         $this->loadFixtures($em);
 
-        $factory = new AdapterFactory($this->doctrine, 'USD', array('EUR'), self::CURRENCY_ENTITY);
+        $factory = new AdapterFactory($this->doctrine, 'USD', ['EUR'], Currency::class);
         $adapter = $factory->createDoctrineAdapter();
 
-        $this->assertInstanceOf('Lexik\Bundle\CurrencyBundle\Adapter\DoctrineCurrencyAdapter', $adapter);
+        $this->assertInstanceOf(DoctrineCurrencyAdapter::class, $adapter);
         $this->assertEquals('USD', $adapter->getDefaultCurrency());
-        $this->assertEquals(array('EUR'), $adapter->getManagedCurrencies());
+        $this->assertEquals(['EUR'], $adapter->getManagedCurrencies());
         $this->assertEquals(0, count($adapter));
 
-        $adapter['USD']; // force initialization
+        $adapter['USD']; // force initialization // @phpstan-ignore-line
         $this->assertEquals(2, count($adapter));
     }
 }

--- a/Tests/Unit/Converter/ConverterTest.php
+++ b/Tests/Unit/Converter/ConverterTest.php
@@ -2,19 +2,18 @@
 
 namespace Lexik\Bundle\CurrencyBundle\Tests\Unit\Converter;
 
+use Lexik\Bundle\CurrencyBundle\Adapter\AbstractCurrencyAdapter;
 use Lexik\Bundle\CurrencyBundle\Adapter\AdapterFactory;
 use Lexik\Bundle\CurrencyBundle\Currency\Converter;
+use Lexik\Bundle\CurrencyBundle\Entity\Currency;
+use Lexik\Bundle\CurrencyBundle\Exception\CurrencyNotFoundException;
 use Lexik\Bundle\CurrencyBundle\Tests\Unit\BaseUnitTestCase;
 
 class ConverterTest extends BaseUnitTestCase
 {
-    const CURRENCY_ENTITY = 'Lexik\Bundle\CurrencyBundle\Entity\Currency';
+    private AbstractCurrencyAdapter $adapter;
 
-    protected $doctrine;
-
-    private $adapter;
-
-    public function setUp()
+    public function setUp(): void
     {
         $this->doctrine = $this->getMockDoctrine();
         $em = $this->getEntityManager();
@@ -22,11 +21,11 @@ class ConverterTest extends BaseUnitTestCase
         $this->createSchema($em);
         $this->loadFixtures($em);
 
-        $factory = new AdapterFactory($this->doctrine, 'EUR', array('EUR', 'USD'), self::CURRENCY_ENTITY);
+        $factory = new AdapterFactory($this->doctrine, 'EUR', ['EUR', 'USD'], Currency::class);
         $this->adapter = $factory->createDoctrineAdapter();
     }
 
-    public function testConvert()
+    public function testConvert(): void
     {
         $converter = new Converter($this->adapter);
 
@@ -39,7 +38,7 @@ class ConverterTest extends BaseUnitTestCase
         $this->assertEquals(8.666, $converter->convert(8.666, 'EUR'));
     }
 
-    public function testConvertNotRounded()
+    public function testConvertNotRounded(): void
     {
         $converter = new Converter($this->adapter);
 
@@ -47,7 +46,7 @@ class ConverterTest extends BaseUnitTestCase
         $this->assertEquals(8.666, $converter->convert(8.666, 'EUR', false));
     }
 
-    public function testConvertFromNoDefaultCurrency()
+    public function testConvertFromNoDefaultCurrency(): void
     {
         $converter = new Converter($this->adapter);
 
@@ -55,7 +54,7 @@ class ConverterTest extends BaseUnitTestCase
         $this->assertEquals(6.67, $converter->convert(8.666, 'EUR', true, 'USD'));
     }
 
-    public function testConvertFromNoDefaultCurrencyNotRounded()
+    public function testConvertFromNoDefaultCurrencyNotRounded(): void
     {
         $converter = new Converter($this->adapter);
 
@@ -63,13 +62,12 @@ class ConverterTest extends BaseUnitTestCase
         $this->assertEquals(6.6661538461538, $converter->convert(8.666, 'EUR', false, 'USD'));
     }
 
-    /**
-     * @expectedException        Lexik\Bundle\CurrencyBundle\Exception\CurrencyNotFoundException
-     * @expectedExceptionMessage Can't find currency: "UUU"
-     */
-    public function testConvertUndefinedTarget()
+    public function testConvertUndefinedTarget(): void
     {
         $converter = new Converter($this->adapter);
+
+        $this->expectException(CurrencyNotFoundException::class);
+        $this->expectExceptionMessage('Cannot find currency: "UUU"');
 
         $converter->convert(8.666, 'UUU');
     }

--- a/Tests/Unit/Twig/Extension/CurrencyExtensionTest.php
+++ b/Tests/Unit/Twig/Extension/CurrencyExtensionTest.php
@@ -2,22 +2,22 @@
 
 namespace Lexik\Bundle\CurrencyBundle\Tests\Unit\Twig\Extension;
 
-use Lexik\Bundle\CurrencyBundle\Currency\Converter;
+use Doctrine\Bundle\DoctrineBundle\Registry;
 use Lexik\Bundle\CurrencyBundle\Adapter\AdapterFactory;
+use Lexik\Bundle\CurrencyBundle\Currency\Converter;
 use Lexik\Bundle\CurrencyBundle\Currency\Formatter;
-use Lexik\Bundle\CurrencyBundle\Twig\Extension\CurrencyExtension;
+use Lexik\Bundle\CurrencyBundle\Entity\Currency;
 use Lexik\Bundle\CurrencyBundle\Tests\Unit\BaseUnitTestCase;
+use Lexik\Bundle\CurrencyBundle\Twig\Extension\CurrencyExtension;
 use Symfony\Component\DependencyInjection\Container;
 
 class CurrencyExtensionTest extends BaseUnitTestCase
 {
-    const CURRENCY_ENTITY = 'Lexik\Bundle\CurrencyBundle\Entity\Currency';
+    public Registry $doctrine;
 
-    protected $doctrine;
+    private Container $container;
 
-    private $container;
-
-    public function setUp()
+    public function setUp(): void
     {
         $this->doctrine = $this->getMockDoctrine();
         $em = $this->getEntityManager();
@@ -25,7 +25,7 @@ class CurrencyExtensionTest extends BaseUnitTestCase
         $this->createSchema($em);
         $this->loadFixtures($em);
 
-        $factory = new AdapterFactory($this->doctrine, 'EUR', array('EUR', 'USD'), self::CURRENCY_ENTITY);
+        $factory = new AdapterFactory($this->doctrine, 'EUR', ['EUR', 'USD'], Currency::class);
 
         $converter = new Converter($factory->createDoctrineAdapter());
 
@@ -36,7 +36,7 @@ class CurrencyExtensionTest extends BaseUnitTestCase
         $this->container->set('lexik_currency.formatter', $formatter);
     }
 
-    public function testConvert()
+    public function testConvert(): void
     {
         $extension = new CurrencyExtension($this->container);
 
@@ -44,7 +44,7 @@ class CurrencyExtensionTest extends BaseUnitTestCase
         $this->assertEquals(8.67, $extension->convert(8.666, 'EUR'));
     }
 
-    public function testFormat()
+    public function testFormat(): void
     {
         $extension = new CurrencyExtension($this->container);
 
@@ -52,20 +52,20 @@ class CurrencyExtensionTest extends BaseUnitTestCase
         $this->assertEquals('8,67 €', $extension->format(8.666, 'EUR'));
         $this->assertEquals('8,67 $', $extension->format(8.666, 'USD'));
         $this->assertEquals('8 $', $extension->format(8.0, 'USD', false));
-        $this->assertEquals('8,666', $extension->format(8.666, 'USD', false, false));
-        $this->assertEquals('8', $extension->format(8.0, 'USD', true, false));
+        $this->assertEquals('8,67', $extension->format(8.666, 'USD', false, false));
+        $this->assertEquals('8', $extension->format(8.0, 'USD', false, false));
         $this->assertEquals('8 $', $extension->format(8.0, 'USD', false, true));
     }
 
-    public function testConvertAndFormat()
+    public function testConvertAndFormat(): void
     {
         $extension = new CurrencyExtension($this->container);
 
         $this->assertEquals('11,27 $', $extension->convertAndFormat(8.666, 'USD'));
         $this->assertEquals('11,27 $', $extension->convertAndFormat(8.666, 'USD', false));
-        $this->assertEquals('11,2658', $extension->convertAndFormat(8.666, 'USD', false, false));
+        $this->assertEquals('11,27', $extension->convertAndFormat(8.666, 'USD', false, false));
         $this->assertEquals('8,67', $extension->convertAndFormat(8.666, 'USD', true, false, 'USD'));
-        $this->assertEquals('8', $extension->convertAndFormat(8.0, 'USD', true, false, 'USD'));
+        $this->assertEquals('8,00', $extension->convertAndFormat(8.0, 'USD', true, false, 'USD'));
         $this->assertEquals('8,00 $', $extension->convertAndFormat(8.0, 'USD', true, true, 'USD'));
         $this->assertEquals('8 $', $extension->convertAndFormat(8.0, 'USD', false, true, 'USD'));
     }

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -1,7 +1,7 @@
 <?php
 
-if (file_exists($file = __DIR__.'/autoload.php')) {
+if (file_exists($file = __DIR__ . '/autoload.php')) {
     require_once $file;
-} elseif (file_exists($file = __DIR__.'/autoload.php.dist')) {
+} elseif (file_exists($file = __DIR__ . '/autoload.php.dist')) {
     require_once $file;
 }

--- a/Twig/Extension/CurrencyExtension.php
+++ b/Twig/Extension/CurrencyExtension.php
@@ -2,7 +2,11 @@
 
 namespace Lexik\Bundle\CurrencyBundle\Twig\Extension;
 
+use Lexik\Bundle\CurrencyBundle\Currency\ConverterInterface;
+use Lexik\Bundle\CurrencyBundle\Currency\FormatterInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
 
 /**
  * Twig extension to format and convert currencies from templates.
@@ -10,75 +14,46 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * @author Cédric Girard <c.girard@lexik.fr>
  * @author Yoann Aparici <y.aparici@lexik.fr>
  */
-class CurrencyExtension extends \Twig_Extension
+class CurrencyExtension extends AbstractExtension
 {
-    /**
-     * @var ContainerInterface
-     */
-    protected $container;
+    protected ContainerInterface $container;
 
-    /**
-     * Construct.
-     *
-     * @param ContainerInterface $container  We need the entire container to lazy load the Converter
-     */
     public function __construct(ContainerInterface $container)
     {
         $this->container = $container;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getFilters()
+    public function getFilters(): array
     {
-        return array(
-            new \Twig_SimpleFilter('currency_convert', array($this, 'convert')),
-            new \Twig_SimpleFilter('currency_format', array($this, 'format')),
-            new \Twig_SimpleFilter('currency_convert_format', array($this, 'convertAndFormat')),
-        );
+        return [
+            new TwigFilter('currency_convert', [$this, 'convert']),
+            new TwigFilter('currency_format', [$this, 'format']),
+            new TwigFilter('currency_convert_format', [$this, 'convertAndFormat']),
+        ];
     }
 
-    /**
-     * @return \Lexik\Bundle\CurrencyBundle\Currency\ConverterInterface
-     */
-    public function getConverter()
+    public function getConverter(): ConverterInterface
     {
-        return $this->container->get('lexik_currency.converter');
+        $converter = $this->container->get('lexik_currency.converter');
+        assert($converter instanceof ConverterInterface);
+
+        return $converter;
     }
 
-    /**
-     * @return \Lexik\Bundle\CurrencyBundle\Currency\FormatterInterface
-     */
-    public function getFormatter()
+    public function getFormatter(): FormatterInterface
     {
-        return $this->container->get('lexik_currency.formatter');
+        $formatter = $this->container->get('lexik_currency.formatter');
+        assert($formatter instanceof FormatterInterface);
+
+        return $formatter;
     }
 
-    /**
-     * Convert the given value.
-     *
-     * @param float   $value
-     * @param string  $targetCurrency  target currency code
-     * @param boolean $round      roud converted value
-     * @param string  $valueCurrency   $value currency code
-     * @return float
-     */
-    public function convert($value, $targetCurrency, $round = true, $valueCurrency = null)
+    public function convert(float $value, string $targetCurrency, bool $round = true, string $valueCurrency = null): float
     {
         return $this->getConverter()->convert($value, $targetCurrency, $round, $valueCurrency);
     }
 
-    /**
-     * Format the given value.
-     *
-     * @param mixed   $value
-     * @param string  $valueCurrency  $value currency code
-     * @param boolean $decimal        show decimal part
-     * @param boolean $symbol         show currency symbol
-     * @return string
-     */
-    public function format($value, $valueCurrency = null, $decimal = true, $symbol = true)
+    public function format(float $value, string $valueCurrency = null, bool $decimal = true, bool $symbol = true): ?string
     {
         if (null === $valueCurrency) {
             $valueCurrency = $this->getConverter()->getDefaultCurrency();
@@ -87,27 +62,14 @@ class CurrencyExtension extends \Twig_Extension
         return $this->getFormatter()->format($value, $valueCurrency, $decimal, $symbol);
     }
 
-    /**
-     * Convert and format the given value.
-     *
-     * @param mixed   $value
-     * @param string  $targetCurrency  target currency code
-     * @param boolean $decimal         show decimal part
-     * @param boolean $symbol          show currency symbol
-     * @param string  $valueCurrency   the $value currency code
-     * @return string
-     */
-    public function convertAndFormat($value, $targetCurrency, $decimal = true, $symbol = true, $valueCurrency = null)
+    public function convertAndFormat(float $value, string $targetCurrency, bool $decimal = true, bool $symbol = true, string $valueCurrency = null): ?string
     {
         $value = $this->convert($value, $targetCurrency, $decimal, $valueCurrency);
 
         return $this->format($value, $targetCurrency, $decimal, $symbol);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
+    public function getName(): string
     {
         return 'lexik_currency.currency_extension';
     }

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
     "name": "lexik/currency-bundle",
     "type": "symfony-bundle",
-    "description": "This Symfony2 bundle provide a service and a Twig extension to convert and display currencies.",
-    "keywords": ["Symfony2", "bundle", "currency"],
+    "description": "This Symfony bundle provide a service and a Twig extension to convert and display currencies.",
+    "keywords": ["Symfony", "bundle", "currency"],
     "homepage": "https://github.com/lexik/LexikCurrencyBundle",
     "license": "MIT",
     "authors": [
@@ -16,8 +16,21 @@
         }
     ],
     "require": {
-        "php": ">=5.5.9",
-        "symfony/framework-bundle": "~2.8|~3.0|~4.0"
+        "php": ">8.0",
+        "ext-curl": "*",
+        "ext-intl": "*",
+        "ext-simplexml": "*",
+        "symfony/framework-bundle": "^5.0 || ^6.0"
+    },
+    "require-dev": {
+        "rector/rector": "^0.12.16",
+        "symplify/easy-coding-standard": "^10.0",
+        "doctrine/orm": "^2.11",
+        "doctrine/doctrine-bundle": "^2.5",
+        "phpunit/phpunit": "^9.5",
+        "doctrine/doctrine-fixtures-bundle": "^3.4",
+        "twig/twig": "^3.3",
+        "symfony/validator": "^6.0"
     },
     "autoload": {
         "psr-4": { "Lexik\\Bundle\\CurrencyBundle\\": "" }

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "symfony/framework-bundle": "~2.8|~3.0"
+        "symfony/framework-bundle": "~2.8|~3.0|~4.0"
     },
     "autoload": {
         "psr-4": { "Lexik\\Bundle\\CurrencyBundle\\": "" }

--- a/ecs.php
+++ b/ecs.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use PhpCsFixer\Fixer\ArrayNotation\ArraySyntaxFixer;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\EasyCodingStandard\ValueObject\Option;
+use Symplify\EasyCodingStandard\ValueObject\Set\SetList;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $parameters = $containerConfigurator->parameters();
+    $parameters->set(Option::PATHS, [
+        __DIR__
+    ]);
+    $parameters->set(Option::PARALLEL, true);
+
+    $containerConfigurator->import(SetList::PSR_12);
+
+    $services = $containerConfigurator->services();
+    $services->set(ArraySyntaxFixer::class)
+        ->call('configure', [[
+            'syntax' => 'short',
+        ]]);
+};

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,19 @@
+
+parameters:
+
+    level: 9
+
+    paths:
+        - Adapter
+        - Command
+        - Currency
+        - DependencyInjection
+        - Entity
+        - EventListener
+        - Exception
+        - Resources
+        - Tests
+        - Twig
+
+    ignoreErrors:
+        - '#NodeDefinition::addDefaultsIfNotSet\(\)#'

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,34 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
-         syntaxCheck="false"
          bootstrap="Tests/bootstrap.php"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
 >
+    <coverage>
+        <include>
+            <directory>./Adapter</directory>
+            <directory>./Command</directory>
+            <directory>./Currency</directory>
+            <directory>./DependencyInjection</directory>
+            <directory>./Entity</directory>
+            <directory>./EventListener</directory>
+            <directory>./Exception</directory>
+            <directory>./Twig</directory>
+        </include>
+        <exclude>
+            <directory>./Resources</directory>
+            <directory>./Tests</directory>
+            <directory>./vendor</directory>
+        </exclude>
+    </coverage>
     <testsuites>
         <testsuite name="LexikCurrencyBundle Test Suite">
             <directory>./Tests/</directory>
         </testsuite>
     </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./</directory>
-            <exclude>
-                <directory>./Resources</directory>
-                <directory>./Tests</directory>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
-
     <php>
-        <server name="ROOT_DIR" value="../../../../.." />
+        <server name="ROOT_DIR" value="../../../../.."/>
     </php>
 </phpunit>

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Core\Configuration\Option;
+use Rector\Php74\Rector\Property\TypedPropertyRector;
+use Rector\Set\ValueObject\SetList;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $parameters = $containerConfigurator->parameters();
+
+    $parameters->set(Option::PATHS, [
+        __DIR__ . '/Adapter',
+        __DIR__ . '/Command',
+        __DIR__ . '/Currency',
+        __DIR__ . '/DependencyInjection',
+        __DIR__ . '/Entity',
+        __DIR__ . '/EventListener',
+        __DIR__ . '/Exception',
+        __DIR__ . '/Resources',
+        __DIR__ . '/Tests',
+        __DIR__ . '/Twig',
+    ]);
+    $parameters->set(Option::PARALLEL, true);
+
+    $containerConfigurator->import(SetList::TYPE_DECLARATION);
+    $containerConfigurator->import(SetList::CODE_QUALITY);
+    $containerConfigurator->import(SetList::PHP_80);
+    $containerConfigurator->import(SetList::PHP_74);
+    $containerConfigurator->import(SetList::PHP_73);
+    $containerConfigurator->import(SetList::PHP_72);
+    $containerConfigurator->import(SetList::PHP_71);
+    $containerConfigurator->import(SetList::PHP_70);
+
+    //$services = $containerConfigurator->services();
+    //$services->set(TypedPropertyRector::class);
+};


### PR DESCRIPTION
Replaced PHPDoc comments with typed parameters and return types.
Removed superfluous comments.
Upgraded to PHPUnit 9.5
Added required PHP extensions to composer.json.
Fixed all static analysis issues to PHPStan level 9.
Formatted code to PSR-12 using Easy Coding Standard.

Generally brought the package up to modern PHP standards.